### PR TITLE
feat: add bucketPolicy and bucketLifecycle parameters to CephBucket

### DIFF
--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -86,10 +86,14 @@ spec:
                         description: Maximum number of objects in the bucket
                         default: "10000"
                       bucketPolicy:
-                        type: string
+                        type: object
+                        additionalProperties:
+                          type: string
                         description: Bucket policy in JSON format
                       bucketLifecycle:
-                        type: string
+                        type: object
+                        additionalProperties:
+                          type: string
                         description: Bucket lifecycle policy in JSON format
                   secret:
                     type: object

--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -87,11 +87,11 @@ spec:
                         default: "10000"
                       bucketPolicy:
                         type: object
-                        additionalProperties: {}
+                        x-kubernetes-preserve-unknown-fields: true
                         description: Bucket policy
                       bucketLifecycle:
                         type: object
-                        additionalProperties: {}
+                        x-kubernetes-preserve-unknown-fields: true
                         description: Bucket lifecycle
                   secret:
                     type: object

--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -87,13 +87,11 @@ spec:
                         default: "10000"
                       bucketPolicy:
                         type: object
-                        additionalProperties:
-                          type: string
+                        additionalProperties: true
                         description: Bucket policy in JSON format
                       bucketLifecycle:
                         type: object
-                        additionalProperties:
-                          type: string
+                        additionalProperties: true
                         description: Bucket lifecycle policy in JSON format
                   secret:
                     type: object

--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -85,6 +85,12 @@ spec:
                         type: string
                         description: Maximum number of objects in the bucket
                         default: "10000"
+                      bucketPolicy:
+                        type: string
+                        description: Bucket policy in JSON format
+                      bucketLifecycle:
+                        type: string
+                        description: Bucket lifecycle policy in JSON format
                   secret:
                     type: object
                     description: |-

--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -88,11 +88,11 @@ spec:
                       bucketPolicy:
                         type: object
                         additionalProperties: true
-                        description: Bucket policy in JSON format
+                        description: Bucket policy
                       bucketLifecycle:
                         type: object
                         additionalProperties: true
-                        description: Bucket lifecycle policy in JSON format
+                        description: Bucket lifecycle
                   secret:
                     type: object
                     description: |-

--- a/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/resources/definition.yaml
@@ -87,11 +87,11 @@ spec:
                         default: "10000"
                       bucketPolicy:
                         type: object
-                        additionalProperties: true
+                        additionalProperties: {}
                         description: Bucket policy
                       bucketLifecycle:
                         type: object
-                        additionalProperties: true
+                        additionalProperties: {}
                         description: Bucket lifecycle
                   secret:
                     type: object

--- a/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
+++ b/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
@@ -32,6 +32,8 @@ _cephBucket= {
           storageClassName   = parameters?.bucket?.storageClassName
           additionalConfig   = {
             maxSize    = parameters?.bucket?.maxSize
+            if parameters?.bucket?.bucketPolicy: bucketPolicy = parameters?.bucket?.bucketPolicy
+            if parameters?.bucket?.bucketLifecycle: bucketLifecycle = parameters?.bucket?.bucketLifecycle
           }
         }
       }

--- a/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
+++ b/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
@@ -1,3 +1,4 @@
+import json
 # Read the XR and the OCDs
 oxr: any = option("params").oxr
 ocds: any = option("params").ocds

--- a/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
+++ b/packages/objectstores/compositions/ceph-bucket/resources/kcl-step.k
@@ -32,8 +32,8 @@ _cephBucket= {
           storageClassName   = parameters?.bucket?.storageClassName
           additionalConfig   = {
             maxSize    = parameters?.bucket?.maxSize
-            if parameters?.bucket?.bucketPolicy: bucketPolicy = parameters?.bucket?.bucketPolicy
-            if parameters?.bucket?.bucketLifecycle: bucketLifecycle = parameters?.bucket?.bucketLifecycle
+            if parameters?.bucket?.bucketPolicy: bucketPolicy = json.encode(parameters?.bucket?.bucketPolicy)
+            if parameters?.bucket?.bucketLifecycle: bucketLifecycle = json.encode(parameters?.bucket?.bucketLifecycle)
           }
         }
       }

--- a/packages/objectstores/compositions/ceph-bucket/test/scenarios/additional/claim.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/test/scenarios/additional/claim.yaml
@@ -1,0 +1,35 @@
+apiVersion: objectstore.mojaloop.io/v1alpha1
+kind: XCephBucket
+metadata:
+  name: test-bucket1
+spec:
+  providerConfigsRef:
+    scK8sProviderName: sc-kubernetes-provider
+    ccK8sProviderName: kubernetes-provider
+  parameters:
+    bucket:
+      bucketName: "my-example-bucket"
+      storageClassName: "ceph-bucket"
+      maxSize: "10Gi"
+    secret:
+      scNamespace: "rook-ceph"
+      name: "my-example-bucket"
+      ccNamespace: "temp"
+      esoPushSecret: true
+      vaultSecretStore: "vault-backend"
+      vaultSecretPath: "mutai/my_example_bucket2"
+    bucketPolicy:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal: "*"
+          Action: s3:GetObject
+          Resource:
+            - arn:aws:s3:::report
+    bucketLifecycle:
+      Rules:
+        - ID: ExpireAfter7Days
+          Status: Enabled
+          Prefix: ""
+          Expiration:
+            Days: 7

--- a/packages/objectstores/compositions/ceph-bucket/test/scenarios/additional/claim.yaml
+++ b/packages/objectstores/compositions/ceph-bucket/test/scenarios/additional/claim.yaml
@@ -11,6 +11,21 @@ spec:
       bucketName: "my-example-bucket"
       storageClassName: "ceph-bucket"
       maxSize: "10Gi"
+      bucketPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: s3:GetObject
+            Resource:
+              - arn:aws:s3:::report
+      bucketLifecycle:
+        Rules:
+          - ID: ExpireAfter7Days
+            Status: Enabled
+            Prefix: ""
+            Expiration:
+              Days: 7
     secret:
       scNamespace: "rook-ceph"
       name: "my-example-bucket"
@@ -18,18 +33,3 @@ spec:
       esoPushSecret: true
       vaultSecretStore: "vault-backend"
       vaultSecretPath: "mutai/my_example_bucket2"
-    bucketPolicy:
-      Version: "2012-10-17"
-      Statement:
-        - Effect: Allow
-          Principal: "*"
-          Action: s3:GetObject
-          Resource:
-            - arn:aws:s3:::report
-    bucketLifecycle:
-      Rules:
-        - ID: ExpireAfter7Days
-          Status: Enabled
-          Prefix: ""
-          Expiration:
-            Days: 7

--- a/packages/objectstores/compositions/object-store/resources/definition.yaml
+++ b/packages/objectstores/compositions/object-store/resources/definition.yaml
@@ -111,11 +111,11 @@ spec:
                         default: "1000"
                       bucketPolicy:
                         type: object
-                        additionalProperties: true
+                        additionalProperties: {}
                         description: Bucket policy
                       bucketLifecycle:
                         type: object
-                        additionalProperties: true
+                        additionalProperties: {}
                         description: Bucket lifecycle
                   s3:
                     type: object

--- a/packages/objectstores/compositions/object-store/resources/definition.yaml
+++ b/packages/objectstores/compositions/object-store/resources/definition.yaml
@@ -111,11 +111,11 @@ spec:
                         default: "1000"
                       bucketPolicy:
                         type: object
-                        additionalProperties: {}
+                        x-kubernetes-preserve-unknown-fields: true
                         description: Bucket policy
                       bucketLifecycle:
                         type: object
-                        additionalProperties: {}
+                        x-kubernetes-preserve-unknown-fields: true
                         description: Bucket lifecycle
                   s3:
                     type: object

--- a/packages/objectstores/compositions/object-store/resources/definition.yaml
+++ b/packages/objectstores/compositions/object-store/resources/definition.yaml
@@ -109,7 +109,16 @@ spec:
                         type: string
                         description: Maximum number of objects in the bucket
                         default: "1000"
-
+                      bucketPolicy:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: Bucket policy in JSON format
+                      bucketLifecycle:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: Bucket lifecycle policy in JSON format
                   s3:
                     type: object
                     description: AWS bucket variables.

--- a/packages/objectstores/compositions/object-store/resources/definition.yaml
+++ b/packages/objectstores/compositions/object-store/resources/definition.yaml
@@ -111,13 +111,11 @@ spec:
                         default: "1000"
                       bucketPolicy:
                         type: object
-                        additionalProperties:
-                          type: string
+                        additionalProperties: true
                         description: Bucket policy in JSON format
                       bucketLifecycle:
                         type: object
-                        additionalProperties:
-                          type: string
+                        additionalProperties: true
                         description: Bucket lifecycle policy in JSON format
                   s3:
                     type: object

--- a/packages/objectstores/compositions/object-store/resources/definition.yaml
+++ b/packages/objectstores/compositions/object-store/resources/definition.yaml
@@ -112,11 +112,11 @@ spec:
                       bucketPolicy:
                         type: object
                         additionalProperties: true
-                        description: Bucket policy in JSON format
+                        description: Bucket policy
                       bucketLifecycle:
                         type: object
                         additionalProperties: true
-                        description: Bucket lifecycle policy in JSON format
+                        description: Bucket lifecycle
                   s3:
                     type: object
                     description: AWS bucket variables.

--- a/packages/objectstores/compositions/object-store/resources/kcl-step.k
+++ b/packages/objectstores/compositions/object-store/resources/kcl-step.k
@@ -26,6 +26,8 @@ if parameters?.objectStoreProvider == "ceph":
             bucketName               = parameters?.bucketName
             storageClassName         = parameters?.ceph?.storageClassName
             maxSize                  = parameters?.ceph?.maxSize
+            if parameters?.ceph?.bucketPolicy: bucketPolicy = parameters?.ceph?.bucketPolicy
+            if parameters?.ceph?.bucketLifecycle: bucketLifecycle = parameters?.ceph?.bucketLifecycle
           }
           secret = {
             name              = parameters?.bucketName

--- a/packages/objectstores/compositions/object-store/test/scenarios/ceph-additional/claim.yaml
+++ b/packages/objectstores/compositions/object-store/test/scenarios/ceph-additional/claim.yaml
@@ -1,0 +1,33 @@
+apiVersion: objectstore.mojaloop.io/v1alpha1
+kind: XObjectStore
+metadata:
+  name: example-object-store
+spec:
+  parameters:
+    clusterName: "example-cluster"
+    objectStoreProvider: "ceph"
+    bucketName: "my-example-bucket"
+    ccK8sProviderName: "kubernetes-provider"
+    esoPushSecret: false
+    vaultSecretStore: "vault-backend"
+    vaultSecretPath: "objectstore/my_example_bucket"
+    namespace: "default"
+    ceph:
+      scK8sProviderName: "sc-kubernetes-provider"
+      storageClassName: "ceph-bucket"
+      maxSize: "1Gi"
+      bucketPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: s3:GetObject
+            Resource:
+              - arn:aws:s3:::report
+      bucketLifecycle:
+        Rules:
+          - ID: ExpireAfter7Days
+            Status: Enabled
+            Prefix: ""
+            Expiration:
+              Days: 7


### PR DESCRIPTION
This pull request adds support for specifying custom bucket policies and lifecycle rules in both the Ceph bucket and generic object store compositions. The changes update the resource definitions, processing logic, and include new test scenarios to validate these features.

### Schema enhancements

* Added `bucketPolicy` and `bucketLifecycle` fields to the `spec.bucket` section in both `ceph-bucket/resources/definition.yaml` and `object-store/resources/definition.yaml`, allowing users to define custom bucket policies and lifecycle configurations. [[1]](diffhunk://#diff-eac6fb52c4483d94fe57bdb4f8234aac49a986525d5bb4a140d5383af8afcac5R88-R95) [[2]](diffhunk://#diff-0022d78e45f4964de22ab7e28903d0d602a07674c883784dce40e4c5c4b1265eL112-R119)

### Logic updates

* Updated `ceph-bucket/resources/kcl-step.k` to encode and pass `bucketPolicy` and `bucketLifecycle` from parameters to the bucket configuration if provided.
* Updated `object-store/resources/kcl-step.k` to pass `bucketPolicy` and `bucketLifecycle` from Ceph parameters to the bucket configuration if present.

### Test scenario additions

* Added a test scenario in `ceph-bucket/test/scenarios/additional/claim.yaml` demonstrating usage of the new `bucketPolicy` and `bucketLifecycle` fields.
* Added a test scenario in `object-store/test/scenarios/ceph-additional/claim.yaml` for Ceph object store with custom bucket policy and lifecycle rules.

### Other improvements

* Imported the `json` module in `ceph-bucket/resources/kcl-step.k` to support encoding of policy and lifecycle objects.